### PR TITLE
Bounds-check `getTileAt` for invalid ranges

### DIFF
--- a/mapdata.lua
+++ b/mapdata.lua
@@ -61,6 +61,12 @@ function myModule.getMapHeight(mapKey)
 end
 
 function myModule.getTileAt(mapKey, x, y)
+  -- If we are outside the bounds of the map, return false
+  if x < 1 or y < 1 or x > myModule.getMapWidth(mapKey) or y > myModule.getMapHeight(mapKey) then
+    return false
+  end
+  
+  
  local map = maps[mapKey]
  
  return map[y][x] == 1


### PR DESCRIPTION
This change ensures that we don't crash when switching maps when the player is outside the bounds of the map.

We check if the `x` and `y` values passed into`mapdata.getTileAt`exist are within zero and the map's width and height.